### PR TITLE
save text with IO mode "w" instead of "a"

### DIFF
--- a/track.py
+++ b/track.py
@@ -202,7 +202,7 @@ def detect(opt):
                             bbox_w = output[2] - output[0]
                             bbox_h = output[3] - output[1]
                             # Write MOT compliant results to file
-                            with open(txt_path + '.txt', 'a') as f:
+                            with open(txt_path + '.txt', 'w') as f:
                                 f.write(('%g ' * 10 + '\n') % (frame_idx + 1, id, bbox_left,  # MOT format
                                                                bbox_top, bbox_w, bbox_h, -1, -1, -1, i))
 


### PR DESCRIPTION
# TL;DR

IO with "a" will modify exitsing txt without any alarming info. It will ruin the semantical consistency.

---

I know there is encapsulated path management strategy, which ensures the relatively decoupled files hierarchy. However, after figuring out the meanings of the arguments and modifying many codes, I changed several path settings. 

And then, in my custom project folder, some txt, which underwent several times of experiments, recorded duplicate results.

This bug is very concealed and harmful to the Evaluation Algorithms which assume the cleanness of tracking results.

```
466 964 680 235 42 75 -1 -1 -1 0 
466 966 475 326 60 97 -1 -1 -1 0 
3 1 708 282 48 96 -1 -1 -1 0 
3 2 1104 229 44 90 -1 -1 -1 0
```