### PR TITLE
Unused libraries have been removed.

### DIFF
--- a/track.py
+++ b/track.py
@@ -1,4 +1,3 @@
-
 import argparse
 
 import os
@@ -27,12 +26,10 @@ if str(ROOT / 'deep_sort') not in sys.path:
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 import logging
-from yolov5.models.experimental import attempt_load
-from yolov5.utils.downloads import attempt_download
 from yolov5.models.common import DetectMultiBackend
 from yolov5.utils.dataloaders import VID_FORMATS, LoadImages, LoadStreams
 from yolov5.utils.general import (LOGGER, check_img_size, non_max_suppression, scale_coords, check_requirements, cv2,
-                                  check_imshow, xyxy2xywh, increment_path, strip_optimizer, colorstr, print_args)
+                                  check_imshow, xyxy2xywh, increment_path, strip_optimizer, colorstr, print_args, check_file)
 from yolov5.utils.torch_utils import select_device, time_sync
 from yolov5.utils.plots import Annotator, colors, save_one_box
 from deep_sort.utils.parser import get_config


### PR DESCRIPTION
The changes made are:

- Unused libraries have been removed.
- "No module named check_file" > Error resolved

Proposal:
These variables are not used. Do you want me to remove these variables?

conf_thres=0.25,  # confidence threshold
iou_thres=0.45,  # NMS IOU threshold
max_det=1000,  # maximum detections per image        
config_deepsort=ROOT / 'deep_sort/configs/deep_sort.yaml',
classes=None,  # filter by class: --class 0, or --class 0 2 3
agnostic_nms=False,  # class-agnostic NMS
augment=False,  # augmented inference
line_thickness=3,  # bounding box thickness (pixels)
hide_labels=False,  # hide labels
hide_conf=False,  # hide confidences